### PR TITLE
Add market data utilities for downloads and returns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ models/
 
 # OS files
 .DS_Store
+# Allow source data package
+!src/market_ec/data/
+!src/market_ec/data/*
+src/market_ec/data/__pycache__/

--- a/src/market_ec/data/__init__.py
+++ b/src/market_ec/data/__init__.py
@@ -1,0 +1,12 @@
+"""Utilities for downloading and working with market data."""
+
+from .price_loader import PriceRequest, download_prices
+from .returns import compute_log_returns
+from .validators import validate_prices
+
+__all__ = [
+    "PriceRequest",
+    "download_prices",
+    "compute_log_returns",
+    "validate_prices",
+]

--- a/src/market_ec/data/price_loader.py
+++ b/src/market_ec/data/price_loader.py
@@ -1,0 +1,93 @@
+"""Download price data from Yahoo Finance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class PriceRequest:
+    """Request parameters for downloading prices."""
+
+    tickers: Sequence[str]
+    start: str | pd.Timestamp
+    end: str | pd.Timestamp
+    interval: str = "1d"
+
+
+def _clean_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize column names to snake_case."""
+    return df.rename(columns=lambda c: str(c).lower().replace(" ", "_"))
+
+
+def download_prices(req: PriceRequest) -> pd.DataFrame:
+    """Download OHLCV data for the requested tickers.
+
+    Parameters
+    ----------
+    req:
+        Request describing tickers and date range.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns: ticker, date, open, high, low, close,
+        adj_close, volume.
+    """
+
+    data = yf.download(
+        tickers=list(req.tickers),
+        start=req.start,
+        end=req.end,
+        interval=req.interval,
+        auto_adjust=False,
+        progress=False,
+        group_by="ticker",
+        threads=True,
+    )
+
+    if data.empty:
+        return pd.DataFrame(
+            columns=[
+                "ticker",
+                "date",
+                "open",
+                "high",
+                "low",
+                "close",
+                "adj_close",
+                "volume",
+            ]
+        )
+
+    frames = []
+    if isinstance(data.columns, pd.MultiIndex):
+        for ticker in req.tickers:
+            if ticker not in data.columns.levels[0]:
+                continue
+            df_t = data[ticker].copy()
+            df_t = _clean_columns(df_t)
+            df_t["ticker"] = ticker
+            frames.append(df_t.reset_index())
+    else:
+        df_t = _clean_columns(data)
+        df_t["ticker"] = list(req.tickers)[0]
+        frames.append(df_t.reset_index())
+
+    df = pd.concat(frames, ignore_index=True)
+    df = _clean_columns(df)
+    df = df[[
+        "ticker",
+        "date",
+        "open",
+        "high",
+        "low",
+        "close",
+        "adj_close",
+        "volume",
+    ]]
+    return df

--- a/src/market_ec/data/returns.py
+++ b/src/market_ec/data/returns.py
@@ -1,0 +1,33 @@
+"""Return calculations."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def compute_log_returns(df: pd.DataFrame, price_col: str = "adj_close") -> pd.DataFrame:
+    """Compute log returns for each ticker.
+
+    Parameters
+    ----------
+    df:
+        Price DataFrame containing ``ticker``, ``date`` and ``price_col`` columns.
+    price_col:
+        Column to use for price (defaults to ``adj_close``).
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ``ticker``, ``date`` and ``log_return``.
+    """
+
+    if price_col not in df.columns:
+        raise ValueError(f"Missing price column: {price_col}")
+
+    df_sorted = df.sort_values(["ticker", "date"]).copy()
+    df_sorted["log_return"] = df_sorted.groupby("ticker")[price_col].transform(
+        lambda s: np.log(s / s.shift(1))
+    )
+    rets = df_sorted.dropna(subset=["log_return"])
+    return rets[["ticker", "date", "log_return"]]

--- a/src/market_ec/data/validators.py
+++ b/src/market_ec/data/validators.py
@@ -1,0 +1,48 @@
+"""Validation utilities for downloaded price data."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+
+REQUIRED_COLUMNS = [
+    "ticker",
+    "date",
+    "open",
+    "high",
+    "low",
+    "close",
+    "adj_close",
+    "volume",
+]
+
+
+def check_price_columns(df: pd.DataFrame, required: Sequence[str] = REQUIRED_COLUMNS) -> None:
+    """Ensure all required columns are present."""
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns: {missing}")
+
+
+def check_date_continuity(df: pd.DataFrame) -> None:
+    """Check that dates for each ticker are unique and reasonably continuous."""
+    if "date" not in df.columns:
+        raise ValueError("DataFrame must contain a 'date' column")
+    if not pd.api.types.is_datetime64_any_dtype(df["date"]):
+        raise TypeError("date column must be datetime-like")
+
+    for ticker, grp in df.groupby("ticker"):
+        dates = grp["date"].sort_values()
+        if dates.duplicated().any():
+            raise ValueError(f"Duplicate dates found for ticker {ticker}")
+        gaps = dates.diff().dropna().dt.days
+        if (gaps > 5).any():
+            raise ValueError(f"Date gaps detected for ticker {ticker}")
+
+
+def validate_prices(df: pd.DataFrame) -> pd.DataFrame:
+    """Run standard validations on a prices DataFrame."""
+    check_price_columns(df)
+    check_date_continuity(df)
+    return df


### PR DESCRIPTION
## Summary
- add `market_ec.data` package with price download, return calculation, and validation helpers
- expose `PriceRequest`, `download_prices`, `compute_log_returns`, and `validate_prices`
- adjust `.gitignore` to track package

## Testing
- `PYTHONPATH=src python -m pytest tests/test_returns.py::test_compute_log_returns_basic -q`
- `PYTHONPATH=src python -m pytest tests/test_price_loader.py -q` *(skipped)*
- `PYTHONPATH=src python -m pytest -q` *(fails: ModuleNotFoundError for market_ec.models)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9808a848327a986d71beaa264cf