### PR TITLE
Add stochastic model calibration utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ env/
 data/
 dashboard/
 risk/
-models/
+/models/
 *.parquet
 *.csv
 *.xlsx

--- a/src/market_ec/models/__init__.py
+++ b/src/market_ec/models/__init__.py
@@ -1,0 +1,3 @@
+"""Model calibration helpers for market_ec."""
+
+__all__: list[str] = []

--- a/src/market_ec/models/garch.py
+++ b/src/market_ec/models/garch.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import minimize
+
+
+@dataclass(frozen=True)
+class GARCH11Params:
+    """Parameters for a GARCH(1,1) model."""
+
+    mu: float
+    omega: float
+    alpha1: float
+    beta1: float
+    unconditional_var: float
+    persistence: float
+
+    def to_dict(self) -> dict:
+        return {
+            "mu": float(self.mu),
+            "omega": float(self.omega),
+            "alpha1": float(self.alpha1),
+            "beta1": float(self.beta1),
+            "unconditional_var": float(self.unconditional_var),
+            "persistence": float(self.persistence),
+        }
+
+
+def _garch11_negloglike(params: np.ndarray, r: np.ndarray) -> float:
+    mu, omega, alpha, beta = params
+    # Enforce parameter constraints; penalize invalid sets
+    if omega <= 0 or alpha < 0 or beta < 0 or (alpha + beta) >= 0.999:
+        return 1e12
+    eps = r - mu
+    n_obs = eps.size
+    h = np.empty(n_obs)
+    # start variance at unconditional variance
+    h0 = omega / (1.0 - alpha - beta)
+    h[0] = h0
+    for t in range(1, n_obs):
+        h[t] = omega + alpha * eps[t - 1] ** 2 + beta * h[t - 1]
+    ll = 0.5 * (np.log(2 * np.pi) + np.log(h) + (eps**2) / h)
+    return float(np.sum(ll))
+
+
+def fit_garch11(log_returns: pd.Series) -> tuple[GARCH11Params, pd.Series]:
+    """Fit a GARCH(1,1) model to a log-return series.
+
+    Parameters
+    ----------
+    log_returns : pd.Series
+        Series of log returns. Missing values are ignored.
+
+    Returns
+    -------
+    params : :class:`GARCH11Params`
+        Estimated parameter dataclass.
+    std_resid : pd.Series
+        Standardized residuals ``(r_t - mu)/sqrt(h_t)`` from the fitted model.
+    """
+    r = pd.Series(log_returns).dropna().to_numpy(dtype=float)
+    if r.size < 2:
+        raise ValueError("Need at least two observations to fit GARCH")
+
+    mu0 = float(np.mean(r))
+    var0 = float(np.var(r, ddof=1))
+    omega0 = 0.1 * var0
+    alpha0 = 0.05
+    beta0 = 0.9
+    x0 = np.array([mu0, omega0, alpha0, beta0])
+
+    res = minimize(_garch11_negloglike, x0, args=(r,), method="L-BFGS-B")
+    if not res.success:
+        raise RuntimeError("GARCH(1,1) fit did not converge: " + res.message)
+    mu, omega, alpha1, beta1 = res.x
+    eps = r - mu
+    n_obs = r.size
+    h = np.empty(n_obs)
+    h[0] = omega / (1.0 - alpha1 - beta1)
+    for t in range(1, n_obs):
+        h[t] = omega + alpha1 * eps[t - 1] ** 2 + beta1 * h[t - 1]
+
+    std_resid = pd.Series(eps / np.sqrt(h), index=pd.Series(log_returns).dropna().index)
+
+    uncond_var = float(omega / (1.0 - alpha1 - beta1))
+    persistence = float(alpha1 + beta1)
+    params = GARCH11Params(
+        mu=float(mu),
+        omega=float(omega),
+        alpha1=float(alpha1),
+        beta1=float(beta1),
+        unconditional_var=uncond_var,
+        persistence=persistence,
+    )
+    return params, std_resid

--- a/src/market_ec/models/gbm.py
+++ b/src/market_ec/models/gbm.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+TRADING_DAYS: int = 252
+
+
+@dataclass(frozen=True)
+class GBMParams:
+    """Parameters of a geometric Brownian motion."""
+
+    mu_annual: float
+    sigma_annual: float
+
+    def to_dict(self) -> dict:
+        return {
+            "mu_annual": float(self.mu_annual),
+            "sigma_annual": float(self.sigma_annual),
+        }
+
+
+def fit_gbm_from_log_returns(log_returns: pd.Series) -> GBMParams:
+    """Fit GBM parameters from a series of (daily) log returns.
+
+    Parameters
+    ----------
+    log_returns : pd.Series
+        Series of log returns. Missing values are ignored.
+
+    Returns
+    -------
+    GBMParams
+        Dataclass containing annualized drift and volatility.
+    """
+    r = pd.Series(log_returns).dropna().to_numpy(dtype=float)
+    if r.size < 2:
+        raise ValueError("Need at least two observations to fit GBM")
+
+    mu_d = float(np.mean(r))
+    sigma_d = float(np.std(r, ddof=1))
+
+    mu_ann = mu_d * TRADING_DAYS
+    sigma_ann = sigma_d * np.sqrt(TRADING_DAYS)
+
+    return GBMParams(mu_annual=mu_ann, sigma_annual=sigma_ann)

--- a/src/market_ec/models/ou.py
+++ b/src/market_ec/models/ou.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .gbm import TRADING_DAYS
+
+
+@dataclass(frozen=True)
+class OUParams:
+    """Parameters for the Ornstein–Uhlenbeck process."""
+
+    kappa: float
+    theta: float
+    sigma: float
+    dt: float
+
+    def to_dict(self) -> dict:
+        return {
+            "kappa": float(self.kappa),
+            "theta": float(self.theta),
+            "sigma": float(self.sigma),
+            "dt": float(self.dt),
+        }
+
+
+def fit_ou_from_log_price(log_price: pd.Series, dt: float | None = None) -> OUParams:
+    """Fit continuous-time OU parameters from a log-price series.
+
+    The discrete-time dynamics are assumed to follow an AR(1) process:
+    ``x_{t+1} = a + b x_t + eps_t``.  Parameters are then mapped to the
+    continuous-time OU process ``dX_t = kappa (theta - X_t) dt + sigma dW_t``.
+
+    Parameters
+    ----------
+    log_price : pd.Series
+        Series of log prices. Missing values are ignored.
+    dt : float, optional
+        Time step in years. Defaults to ``1/TRADING_DAYS``.
+    """
+    x = pd.Series(log_price).dropna().to_numpy(dtype=float)
+    if x.size < 2:
+        raise ValueError("Need at least two observations to fit OU")
+
+    if dt is None:
+        dt = 1.0 / TRADING_DAYS
+
+    x_t = x[:-1]
+    x_tp1 = x[1:]
+    design = np.column_stack([np.ones_like(x_t), x_t])
+    # Ordinary least squares: x_{t+1} = a + b x_t
+    beta, _, _, _ = np.linalg.lstsq(design, x_tp1, rcond=None)
+    a, b = beta
+    resid = x_tp1 - (a + b * x_t)
+    s2 = np.var(resid, ddof=2)
+
+    # Map to continuous-time parameters
+    kappa = -np.log(b) / dt
+    theta = a / (1.0 - b)
+    sigma = np.sqrt(s2 * 2.0 * kappa / (1.0 - b**2))
+
+    return OUParams(kappa=float(kappa), theta=float(theta), sigma=float(sigma), dt=float(dt))


### PR DESCRIPTION
## Summary
- Add `models` package with GBM, OU and GARCH calibration helpers
- Provide dataclasses and `fit_*` functions for each model
- Update `.gitignore` to allow committing source model code

## Testing
- `ruff check src/market_ec/models/gbm.py src/market_ec/models/ou.py src/market_ec/models/garch.py src/market_ec/models/__init__.py`
- `PYTHONPATH=src pytest` *(fails: ModuleNotFoundError: No module named 'market_ec.data')*

------
https://chatgpt.com/codex/tasks/task_e_689bbdf695c08327af4adade0204dd49